### PR TITLE
【Fixed】`rails g`コマンドの際にいらないファイルが生成されないようにする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,11 @@ module Achieve
         request_specs: false
       g.fixture_replacement :factory_girl, dir: "spec/factories"
     end
+
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
#1
config/apprication.rbに不要ファイルを作成しない設定を追加